### PR TITLE
Support additional task ARN formats for determining log stream names

### DIFF
--- a/ecs-run-task-waiter
+++ b/ecs-run-task-waiter
@@ -57,7 +57,7 @@ function assertRequiredArgumentsSet() {
 
 function buildLogStreamName() {
   task_arn=$1
-  task_id="$(echo $task_arn | awk -F / '{print $2}')"
+  task_id="$(echo $task_arn | awk -F / '{print $NF}')"
   container_name=$2
   prefix=$3
   echo "${prefix}/${container_name}/${task_id}"


### PR DESCRIPTION
When running this with the `--output-log` option, `buildLogStreamName` was not grabbing the correct part of the taskArn to determine the task ID for my task. This changes the `awk` command to pull the last field, no matter how many there are, as opposed to the second field.